### PR TITLE
spaces are no longer allowed in the plugin name

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,4 +1,4 @@
-name: Auto AirDrop
+name: AutoAirDrop
 main: me.Vedronex.AAD.AutoAirDrop
 author: Min3CraftDud3 - Vedronex
 version: 1.2


### PR DESCRIPTION
spigot 1.12 doesn't allow spaces in the plugin name anymore, due to the addition of namespacekeys to minecraft.